### PR TITLE
Prevent exception if no znode.data is None

### DIFF
--- a/zktreeutil.py
+++ b/zktreeutil.py
@@ -155,10 +155,10 @@ class ZkTreeUtil(object):
 		"""
 		print('ZNode path: %s' % znode.path)
 		print('ZNode stat: %s' % str(znode.stat))
-		if len(znode.data) == 0:
-			print('ZNode data: (empty)\n')
-		else:	
+		if znode.data and len(znode.data) >= 0:
 			print('ZNode data: %s\n' % znode.data)
+		else:
+			print('ZNode data: (empty)\n')
 
 
 	def process_znode_write_to_zk(self, znode, dest_zk_client, dest_zk_path, resolve):


### PR DESCRIPTION
I encountered a server which had `None` for `znode.data` when expecting a list, this made the script crash:
```$ ./zktreeutil.py --print zoo:2181/
2018-10-27 09:31:25,005 - zk-util - INFO - Running action: PRINT
ZNode path: /
ZNode stat: ZnodeStat(czxid=0, mzxid=0, ctime=0, mtime=0, version=0, cversion=0, aversion=0, ephemeralOwner=0, dataLength=0, numChildren=2, pzxid=4)
ZNode data: (empty)

[...]

ZNode path: /abcd
ZNode stat: ZnodeStat(czxid=4, mzxid=4, ctime=1540632660938, mtime=1540632660938, version=0, cversion=0, aversion=0, ephemeralOwner=0, dataLength=0, numChildren=0, pzxid=4)
Traceback (most recent call last):
  File "./zktreeutil.py", line 270, in <module>
    main()
  File "./zktreeutil.py", line 266, in main
    util.run()
  File "./zktreeutil.py", line 260, in run
    self.run_print(source_zk, source_zk_path)
  File "./zktreeutil.py", line 232, in run_print
    self.traverse_zk_tree(source_zk_client, source_zk_path, self.process_znode_print)
  File "./zktreeutil.py", line 150, in traverse_zk_tree
    self.traverse_zk_tree(src_zk_client, child_path, process_znode, **process_znode_kwargs)
  File "./zktreeutil.py", line 146, in traverse_zk_tree
    process_znode(znode, **process_znode_kwargs)
  File "./zktreeutil.py", line 158, in process_znode_print

    if len(znode.data) == 0:
TypeError: object of type 'NoneType' has no len()
```

Steps to reproduce the `None` value for a znode:
```
In [1]: from kazoo.client import KazooClient
In [2]: zk = KazooClient('zoo:2181')
In [3]: zk.start()
In [4]: help(zk.create)
In [5]: zk.create('/abcd/', value=None)
Out[5]: u'/abcd'
In [6]: zk.get('/abcd/')
Out[6]: 
(None,
 ZnodeStat(czxid=4, mzxid=4, ctime=1540632660938, mtime=1540632660938, version=0, cversion=0, aversion=0, ephemeralOwner=0, dataLength=0, numChildren=0, pzxid=4))
```